### PR TITLE
Add Mercado Pago Bids module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .env
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
 # ml-erp
+
+This repository contains custom Odoo modules.
+
+## Available Modules
+- `mercado_pago_bids`: track Mercado Pago acquisitions with Kanban and customizable fields.

--- a/addons/mercado_pago_bids/__init__.py
+++ b/addons/mercado_pago_bids/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/addons/mercado_pago_bids/__manifest__.py
+++ b/addons/mercado_pago_bids/__manifest__.py
@@ -1,0 +1,13 @@
+{
+    'name': 'Mercado Pago Bids',
+    'version': '1.0',
+    'summary': 'Manage Mercado Pago acquisitions',
+    'author': 'Auto Generated',
+    'license': 'LGPL-3',
+    'depends': ['base'],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/mercado_pago_bid_views.xml',
+    ],
+    'application': True,
+}

--- a/addons/mercado_pago_bids/models/__init__.py
+++ b/addons/mercado_pago_bids/models/__init__.py
@@ -1,0 +1,2 @@
+from . import bid
+from . import custom_field

--- a/addons/mercado_pago_bids/models/bid.py
+++ b/addons/mercado_pago_bids/models/bid.py
@@ -1,0 +1,32 @@
+from odoo import fields, models
+
+
+class MercadoPagoBid(models.Model):
+    _name = 'mercado_pago.bid'
+    _description = 'Mercado Pago Bid'
+
+    name = fields.Char('Nombre Adquisición')
+    numero_adquisicion = fields.Char('Número Adquisición')
+    tipo_adquisicion = fields.Char('Tipo Adquisición')
+    descripcion = fields.Text('Descripción')
+    organismo = fields.Char('Organismo')
+    region_compradora = fields.Char('Región Compradora')
+    fecha_publicacion = fields.Datetime('Fecha Publicación')
+    fecha_cierre = fields.Datetime('Fecha Cierre')
+    descripcion_producto_servicio = fields.Char('Descripción del producto/servicio')
+    codigo_onu = fields.Char('Código ONU')
+    unidad_medida = fields.Char('Unidad de Medida')
+    cantidad = fields.Float('Cantidad')
+    generico = fields.Char('Genérico')
+    nivel_1 = fields.Char('Nivel 1')
+    nivel_2 = fields.Char('Nivel 2')
+    nivel_3 = fields.Char('Nivel 3')
+    estado = fields.Selection([
+        ('revisar', 'Por Revisar'),
+        ('proceso', 'En Proceso'),
+        ('descartada', 'Descartada'),
+        ('adjudicada', 'Adjudicada'),
+        ('perdida', 'Perdida'),
+    ], string='Estado', default='revisar')
+
+    custom_value_ids = fields.One2many('mercado_pago.custom.value', 'bid_id', string='Custom Values')

--- a/addons/mercado_pago_bids/models/custom_field.py
+++ b/addons/mercado_pago_bids/models/custom_field.py
@@ -1,0 +1,18 @@
+from odoo import fields, models
+
+
+class MercadoPagoCustomField(models.Model):
+    _name = 'mercado_pago.custom.field'
+    _description = 'Custom Field Definition'
+    _rec_name = 'name'
+
+    name = fields.Char('Field Name', required=True)
+
+
+class MercadoPagoCustomValue(models.Model):
+    _name = 'mercado_pago.custom.value'
+    _description = 'Custom Field Value'
+
+    bid_id = fields.Many2one('mercado_pago.bid', string='Bid', ondelete='cascade')
+    field_id = fields.Many2one('mercado_pago.custom.field', string='Field', required=True)
+    value = fields.Char('Value')

--- a/addons/mercado_pago_bids/security/ir.model.access.csv
+++ b/addons/mercado_pago_bids/security/ir.model.access.csv
@@ -1,0 +1,4 @@
+id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
+access_mercado_pago_bid,mercado_pago.bid,model_mercado_pago_bid,,1,1,1,1
+access_mercado_pago_custom_field,mercado_pago.custom.field,model_mercado_pago_custom_field,,1,1,1,1
+access_mercado_pago_custom_value,mercado_pago.custom.value,model_mercado_pago_custom_value,,1,1,1,1

--- a/addons/mercado_pago_bids/views/mercado_pago_bid_views.xml
+++ b/addons/mercado_pago_bids/views/mercado_pago_bid_views.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record id="view_mercado_pago_bid_tree" model="ir.ui.view">
+        <field name="name">mercado.pago.bid.tree</field>
+        <field name="model">mercado_pago.bid</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="numero_adquisicion"/>
+                <field name="tipo_adquisicion"/>
+                <field name="name"/>
+                <field name="organismo"/>
+                <field name="fecha_publicacion"/>
+                <field name="fecha_cierre"/>
+                <field name="estado"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_mercado_pago_bid_form" model="ir.ui.view">
+        <field name="name">mercado.pago.bid.form</field>
+        <field name="model">mercado_pago.bid</field>
+        <field name="arch" type="xml">
+            <form string="Bid">
+                <sheet>
+                    <group>
+                        <field name="numero_adquisicion"/>
+                        <field name="tipo_adquisicion"/>
+                        <field name="name"/>
+                        <field name="descripcion"/>
+                        <field name="organismo"/>
+                        <field name="region_compradora"/>
+                        <field name="fecha_publicacion"/>
+                        <field name="fecha_cierre"/>
+                        <field name="descripcion_producto_servicio"/>
+                        <field name="codigo_onu"/>
+                        <field name="unidad_medida"/>
+                        <field name="cantidad"/>
+                        <field name="generico"/>
+                        <field name="nivel_1"/>
+                        <field name="nivel_2"/>
+                        <field name="nivel_3"/>
+                        <field name="estado"/>
+                    </group>
+                    <notebook>
+                        <page string="Custom Fields">
+                            <field name="custom_value_ids">
+                                <tree editable="bottom">
+                                    <field name="field_id"/>
+                                    <field name="value"/>
+                                </tree>
+                            </field>
+                        </page>
+                    </notebook>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="view_mercado_pago_bid_kanban" model="ir.ui.view">
+        <field name="name">mercado.pago.bid.kanban</field>
+        <field name="model">mercado_pago.bid</field>
+        <field name="arch" type="xml">
+            <kanban default_group_by="estado">
+                <field name="estado"/>
+                <templates>
+                    <t t-name="kanban-box">
+                        <div class="oe_kanban_global_click">
+                            <strong><field name="name"/></strong>
+                            <div><field name="numero_adquisicion"/></div>
+                            <div><field name="tipo_adquisicion"/></div>
+                        </div>
+                    </t>
+                </templates>
+            </kanban>
+        </field>
+    </record>
+
+    <record id="action_mercado_pago_bid" model="ir.actions.act_window">
+        <field name="name">Bids</field>
+        <field name="res_model">mercado_pago.bid</field>
+        <field name="view_mode">tree,form,kanban</field>
+    </record>
+
+    <menuitem id="menu_mercado_pago_root" name="Mercado Pago"/>
+    <menuitem id="menu_mercado_pago_bid" name="Bids" parent="menu_mercado_pago_root" action="action_mercado_pago_bid"/>
+    <record id="view_mercado_pago_custom_field_tree" model="ir.ui.view">
+        <field name="name">mercado.pago.custom.field.tree</field>
+        <field name="model">mercado_pago.custom.field</field>
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+            </tree>
+        </field>
+    </record>
+
+    <record id="view_mercado_pago_custom_field_form" model="ir.ui.view">
+        <field name="name">mercado.pago.custom.field.form</field>
+        <field name="model">mercado_pago.custom.field</field>
+        <field name="arch" type="xml">
+            <form string="Custom Field">
+                <sheet>
+                    <group>
+                        <field name="name"/>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="action_mercado_pago_custom_field" model="ir.actions.act_window">
+        <field name="name">Custom Fields</field>
+        <field name="res_model">mercado_pago.custom.field</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="menu_mercado_pago_custom_field" name="Custom Fields" parent="menu_mercado_pago_root" action="action_mercado_pago_custom_field"/>
+</odoo>


### PR DESCRIPTION
## Summary
- add new `mercado_pago_bids` Odoo module with Kanban and custom field support
- document the module in README
- ignore Python cache files

## Testing
- `python -m py_compile addons/mercado_pago_bids/models/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687b02f5f1948327bd1f0b451d1efbdb