### PR TITLE
Update wizard domain support and menu hierarchy

### DIFF
--- a/addons/mercado_pago_bids/views/mercado_pago_bid_views.xml
+++ b/addons/mercado_pago_bids/views/mercado_pago_bid_views.xml
@@ -81,8 +81,10 @@
         <field name="view_mode">tree,form,kanban</field>
     </record>
 
-    <menuitem id="menu_mercado_pago_root" name="Datos Prospeccion"/>
-    <menuitem id="menu_mercado_pago_bid" name="Bids" parent="menu_mercado_pago_root" action="action_mercado_pago_bid"/>
+    <menuitem id="menu_datos_root" name="Datos"/>
+    <menuitem id="menu_mercado_publico" name="Mercado Publico" parent="menu_datos_root" action="action_mercado_pago_bid"/>
+    <menuitem id="menu_sea" name="SEA" parent="menu_datos_root"/>
+    <menuitem id="menu_municipalidades" name="Municipalidades" parent="menu_datos_root"/>
     <record id="view_mercado_pago_custom_field_tree" model="ir.ui.view">
         <field name="name">mercado.pago.custom.field.tree</field>
         <field name="model">mercado_pago.custom.field</field>
@@ -113,5 +115,5 @@
         <field name="view_mode">tree,form</field>
     </record>
 
-    <menuitem id="menu_mercado_pago_custom_field" name="Custom Fields" parent="menu_mercado_pago_root" action="action_mercado_pago_custom_field"/>
+    <menuitem id="menu_mercado_pago_custom_field" name="Custom Fields" parent="menu_datos_root" action="action_mercado_pago_custom_field"/>
 </odoo>

--- a/addons/mercado_pago_bids/wizards/change_state_wizard.py
+++ b/addons/mercado_pago_bids/wizards/change_state_wizard.py
@@ -12,6 +12,21 @@ class ChangeBidStateWizard(models.TransientModel):
     )
 
     def action_confirm(self):
-        bids = self.env['mercado_pago.bid'].browse(self.env.context.get('active_ids', []))
-        bids.write({'estado': self.estado})
-        return {'type': 'ir.actions.act_window_close'}
+        """Apply the new state to the selected bids.
+
+        If the wizard is triggered without explicitly selected records but from
+        a filtered list, ``active_domain`` will contain the domain to apply. In
+        that case we update all bids matching that domain. Otherwise only the
+        records in ``active_ids`` are updated.
+        """
+
+        domain = self.env.context.get("active_domain")
+        if domain and not self.env.context.get("active_ids"):
+            bids = self.env["mercado_pago.bid"].search(domain)
+        else:
+            bids = self.env["mercado_pago.bid"].browse(
+                self.env.context.get("active_ids", [])
+            )
+
+        bids.write({"estado": self.estado})
+        return {"type": "ir.actions.act_window_close"}


### PR DESCRIPTION
## Summary
- allow changing state on all records matching current filter
- restructure menus under `Datos`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c38f3164c8327b5af60d8e35ab825