### PR TITLE
Fix order in remuneraciones_chile manifest

### DIFF
--- a/addons/remuneraciones_chile/__manifest__.py
+++ b/addons/remuneraciones_chile/__manifest__.py
@@ -7,7 +7,6 @@
     "description": "Gestión de remuneraciones para Chile",
     "data": [
         "security/ir.model.access.csv",
-        "views/menus.xml",
         "views/afp_views.xml",
         "views/isapre_views.xml",
         "views/tabla_impuesto_views.xml",
@@ -17,6 +16,7 @@
         "views/empresa_views.xml",
         "views/unidad_views.xml",
         "views/cargo_views.xml",
+        "views/menus.xml",
     ],
     "installable": True,
     "application": True,


### PR DESCRIPTION
## Summary
- fix menu loading order so actions exist before they're referenced

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687c3ddfd77c83278ac04eb9b79b319c