### PR TITLE
Fix access rights for Mercado Pago state wizard

### DIFF
--- a/addons/mercado_pago_bids/security/ir.model.access.csv
+++ b/addons/mercado_pago_bids/security/ir.model.access.csv
@@ -2,3 +2,4 @@ id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_mercado_pago_bid,mercado_pago.bid,model_mercado_pago_bid,,1,1,1,1
 access_mercado_pago_custom_field,mercado_pago.custom.field,model_mercado_pago_custom_field,,1,1,1,1
 access_mercado_pago_custom_value,mercado_pago.custom.value,model_mercado_pago_custom_value,,1,1,1,1
+access_mercado_pago_change_state_wizard,mercado_pago.change.state.wizard,model_mercado_pago_change_state_wizard,,1,1,1,1


### PR DESCRIPTION
## Summary
- allow any user to use the "Change Bid State" wizard

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687c3e9274108327a7c75bbcfcd192ce