### PR TITLE
Fix dependency on mail for Chile payroll module

### DIFF
--- a/addons/remuneraciones_chile/__manifest__.py
+++ b/addons/remuneraciones_chile/__manifest__.py
@@ -1,7 +1,7 @@
 {
     "name": "Remuneraciones Chile",
     "version": "1.0",
-    "depends": ["base"],
+    "depends": ["base", "mail"],
     "author": "Auto Generated",
     "category": "Human Resources",
     "description": "Gestión de remuneraciones para Chile",


### PR DESCRIPTION
## Summary
- fix `remuneraciones_chile` manifest to depend on `mail`

## Testing
- `python -m py_compile addons/remuneraciones_chile/*.py addons/remuneraciones_chile/models/*.py`
- *(failed to run flake8: network disabled)*

------
https://chatgpt.com/codex/tasks/task_e_687c420225dc83278d092c13ce5bc954